### PR TITLE
Mkbleedmask satstar table

### DIFF
--- a/imdetrend_test.build
+++ b/imdetrend_test.build
@@ -9,9 +9,9 @@ echo "Will Install to: $PRODUCT_DIR"
 
 # Do the setup first
 source $EUPS_DIR/desdm_eups_setup.sh
-#setup -v imsupport 7.5.0+0
-setup -v -r $HOME/build-test/imsupport
-setup -v ccfits 2.5+0
+setup -v imsupport 7.5.0+5
+#setup -v -r $HOME/build-test/imsupport
+setup -v ccfits 2.6+0
 setup -v nrecipes 2.0+4
 
 export PREFIX=$PRODUCT_DIR

--- a/src/Makefile
+++ b/src/Makefile
@@ -80,7 +80,7 @@ vpath %.o $(LIBS)
 ################################################################################
 # gcc
 CC :=		gcc -Wall
-CPPC := 	$(CXX)
+CPPC := 	$(CXX) -std=gnu++98
 CPPFLAGS:=      -g -O3
 CPPCOPTS :=	-c -Wall -funroll-loops -O3 -Wno-unused-variable 
 FC :=		f77

--- a/ups/imdetrend.table
+++ b/ups/imdetrend.table
@@ -1,4 +1,4 @@
-setupRequired(imsupport 7.5.0+0)
-setupRequired(ccfits 2.5+0)
+setupRequired(imsupport 7.5.0+5)
+setupRequired(ccfits 2.6+0)
 setupRequired(nrecipes 2.0+4)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)


### PR DESCRIPTION
fix for bookkeeping problem that would arise when trying to check/account for saturated stars that were obscured within bleed trails (resulted in SATSTAR FITS tables with erroneous, sometime-uningestible, entries)
